### PR TITLE
feat: add OpenQuartermaster (OQM) deployment

### DIFF
--- a/apps/kustomization.yaml
+++ b/apps/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - mosquitto/
   - n8n/
   - neolink/
+  - openquartermaster/
 
   - podinfo/
   - postgres/

--- a/apps/openquartermaster/base-station.yaml
+++ b/apps/openquartermaster/base-station.yaml
@@ -1,0 +1,73 @@
+---
+# OQM Base Station (Web UI) Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: oqm-base-station
+  namespace: openquartermaster
+spec:
+  type: ClusterIP
+  selector:
+    app: oqm-base-station
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 80
+---
+# OQM Base Station Deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: oqm-base-station
+  namespace: openquartermaster
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: oqm-base-station
+  template:
+    metadata:
+      labels:
+        app: oqm-base-station
+    spec:
+      containers:
+        - name: base-station
+          image: ebprod/oqm-core-base-station:1.19.2
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 80
+          env:
+            # Core API URL (internal service)
+            - name: OQM_CORE_API_URL
+              value: "http://oqm-core-api"
+            # Keycloak OIDC configuration
+            - name: KEYCLOAK_URL
+              value: "http://oqm-keycloak:8080"
+            - name: KEYCLOAK_REALM
+              value: "oqm"
+            - name: KEYCLOAK_CLIENT_ID
+              value: "oqm-base-station"
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 300m
+              memory: 256Mi
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5

--- a/apps/openquartermaster/core-api.yaml
+++ b/apps/openquartermaster/core-api.yaml
@@ -1,0 +1,91 @@
+---
+# OQM Core API Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: oqm-core-api
+  namespace: openquartermaster
+spec:
+  type: ClusterIP
+  selector:
+    app: oqm-core-api
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 8080
+    - name: management
+      protocol: TCP
+      port: 9090
+      targetPort: 9090
+---
+# OQM Core API Deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: oqm-core-api
+  namespace: openquartermaster
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: oqm-core-api
+  template:
+    metadata:
+      labels:
+        app: oqm-core-api
+    spec:
+      containers:
+        - name: core-api
+          image: ebprod/oqm-core-api:6.1.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+              name: http
+            - containerPort: 9090
+              name: management
+          env:
+            # MongoDB connection
+            - name: QUARKUS_MONGODB_CONNECTION_STRING
+              value: "mongodb://oqm-mongodb:27017"
+            - name: QUARKUS_MONGODB_CREDENTIALS_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: oqm-mongodb-secret
+                  key: MONGO_INITDB_ROOT_USERNAME
+            - name: QUARKUS_MONGODB_CREDENTIALS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: oqm-mongodb-secret
+                  key: MONGO_INITDB_ROOT_PASSWORD
+            # Kafka connection
+            - name: KAFKA_BOOTSTRAP_SERVERS
+              value: "oqm-kafka:9092"
+            # Keycloak/OIDC
+            - name: QUARKUS_OIDC_AUTH_SERVER_URL
+              value: "http://oqm-keycloak:8080/realms/oqm"
+            - name: QUARKUS_OIDC_CLIENT_ID
+              value: "oqm-core-api"
+          resources:
+            requests:
+              cpu: 200m
+              memory: 512Mi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+          livenessProbe:
+            httpGet:
+              path: /q/health/live
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /q/health/ready
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5

--- a/apps/openquartermaster/ingress.yaml
+++ b/apps/openquartermaster/ingress.yaml
@@ -1,0 +1,81 @@
+---
+# Ingress for OQM Base Station (main UI)
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: oqm-base-station-ingress
+  namespace: openquartermaster
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: "50m"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "120"
+spec:
+  ingressClassName: private
+  tls:
+    - hosts:
+        - oqm.orriborri.com
+      secretName: orriborri-com-tls
+  rules:
+    - host: oqm.orriborri.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: oqm-base-station
+                port:
+                  number: 80
+---
+# Ingress for OQM Core API (for direct API access)
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: oqm-api-ingress
+  namespace: openquartermaster
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: "50m"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "120"
+spec:
+  ingressClassName: private
+  tls:
+    - hosts:
+        - oqm-api.orriborri.com
+      secretName: orriborri-com-tls
+  rules:
+    - host: oqm-api.orriborri.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: oqm-core-api
+                port:
+                  number: 80
+---
+# Ingress for Keycloak (needed for auth redirects)
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: oqm-keycloak-ingress
+  namespace: openquartermaster
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: "10m"
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+spec:
+  ingressClassName: private
+  tls:
+    - hosts:
+        - oqm-auth.orriborri.com
+      secretName: orriborri-com-tls
+  rules:
+    - host: oqm-auth.orriborri.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: oqm-keycloak
+                port:
+                  number: 8080

--- a/apps/openquartermaster/kafka.yaml
+++ b/apps/openquartermaster/kafka.yaml
@@ -1,0 +1,90 @@
+---
+# Redpanda (Kafka-compatible) for OQM message broker
+# Using Redpanda as it's lighter weight than full Apache Kafka
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: oqm-redpanda-data
+  namespace: openquartermaster
+spec:
+  storageClassName: nfs-client
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+---
+# Redpanda Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: oqm-kafka
+  namespace: openquartermaster
+spec:
+  type: ClusterIP
+  selector:
+    app: oqm-redpanda
+  ports:
+    - name: kafka
+      protocol: TCP
+      port: 9092
+      targetPort: 9092
+    - name: admin
+      protocol: TCP
+      port: 9644
+      targetPort: 9644
+---
+# Redpanda Deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: oqm-redpanda
+  namespace: openquartermaster
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: oqm-redpanda
+  template:
+    metadata:
+      labels:
+        app: oqm-redpanda
+    spec:
+      containers:
+        - name: redpanda
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.7
+          imagePullPolicy: IfNotPresent
+          command:
+            - rpk
+            - redpanda
+            - start
+            - --smp=1
+            - --memory=512M
+            - --overprovisioned
+            - --kafka-addr=0.0.0.0:9092
+            - --advertise-kafka-addr=oqm-kafka:9092
+          ports:
+            - containerPort: 9092
+            - containerPort: 9644
+          volumeMounts:
+            - name: redpanda-data
+              mountPath: /var/lib/redpanda/data
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 768Mi
+          readinessProbe:
+            httpGet:
+              path: /v1/status/ready
+              port: 9644
+            initialDelaySeconds: 30
+            periodSeconds: 10
+      volumes:
+        - name: redpanda-data
+          persistentVolumeClaim:
+            claimName: oqm-redpanda-data

--- a/apps/openquartermaster/keycloak.yaml
+++ b/apps/openquartermaster/keycloak.yaml
@@ -1,0 +1,194 @@
+---
+# PostgreSQL for Keycloak - PVC
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: oqm-keycloak-db-data
+  namespace: openquartermaster
+spec:
+  storageClassName: nfs-client
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+---
+# PostgreSQL for Keycloak - Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: oqm-keycloak-db
+  namespace: openquartermaster
+spec:
+  type: ClusterIP
+  selector:
+    app: oqm-keycloak-db
+  ports:
+    - name: postgres
+      protocol: TCP
+      port: 5432
+      targetPort: 5432
+---
+# PostgreSQL for Keycloak - Deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: oqm-keycloak-db
+  namespace: openquartermaster
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: oqm-keycloak-db
+  template:
+    metadata:
+      labels:
+        app: oqm-keycloak-db
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:16-alpine
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 5432
+          envFrom:
+            - secretRef:
+                name: oqm-keycloak-db-secret
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 300m
+              memory: 256Mi
+          livenessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - keycloak
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - keycloak
+            initialDelaySeconds: 5
+            periodSeconds: 10
+      volumes:
+        - name: postgres-data
+          persistentVolumeClaim:
+            claimName: oqm-keycloak-db-data
+---
+# Keycloak PVC for themes/extensions
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: oqm-keycloak-data
+  namespace: openquartermaster
+spec:
+  storageClassName: nfs-client
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
+# Keycloak Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: oqm-keycloak
+  namespace: openquartermaster
+spec:
+  type: ClusterIP
+  selector:
+    app: oqm-keycloak
+  ports:
+    - name: http
+      protocol: TCP
+      port: 8080
+      targetPort: 8080
+---
+# Keycloak Deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: oqm-keycloak
+  namespace: openquartermaster
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: oqm-keycloak
+  template:
+    metadata:
+      labels:
+        app: oqm-keycloak
+    spec:
+      containers:
+        - name: keycloak
+          image: quay.io/keycloak/keycloak:25.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - start-dev
+          ports:
+            - containerPort: 8080
+          env:
+            - name: KC_DB
+              value: "postgres"
+            - name: KC_DB_URL
+              value: "jdbc:postgresql://oqm-keycloak-db:5432/keycloak"
+            - name: KC_DB_USERNAME
+              value: "keycloak"
+            - name: KC_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: oqm-keycloak-secret
+                  key: KC_DB_PASSWORD
+            - name: KC_HOSTNAME_STRICT
+              value: "false"
+            - name: KC_PROXY_HEADERS
+              value: "xforwarded"
+            - name: KC_HTTP_ENABLED
+              value: "true"
+          envFrom:
+            - secretRef:
+                name: oqm-keycloak-secret
+          volumeMounts:
+            - name: keycloak-data
+              mountPath: /opt/keycloak/data
+          resources:
+            requests:
+              cpu: 200m
+              memory: 512Mi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+          livenessProbe:
+            httpGet:
+              path: /health/live
+              port: 8080
+            initialDelaySeconds: 120
+            periodSeconds: 30
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /health/ready
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            timeoutSeconds: 5
+      volumes:
+        - name: keycloak-data
+          persistentVolumeClaim:
+            claimName: oqm-keycloak-data

--- a/apps/openquartermaster/kustomization.yaml
+++ b/apps/openquartermaster/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./secrets.yaml
+  - ./mongodb.yaml
+  - ./kafka.yaml
+  - ./keycloak.yaml
+  - ./core-api.yaml
+  - ./base-station.yaml
+  - ./ingress.yaml

--- a/apps/openquartermaster/mongodb.yaml
+++ b/apps/openquartermaster/mongodb.yaml
@@ -1,0 +1,90 @@
+---
+# MongoDB PersistentVolumeClaim
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: oqm-mongodb-data
+  namespace: openquartermaster
+spec:
+  storageClassName: nfs-client
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+---
+# MongoDB Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: oqm-mongodb
+  namespace: openquartermaster
+spec:
+  type: ClusterIP
+  selector:
+    app: oqm-mongodb
+  ports:
+    - name: mongodb
+      protocol: TCP
+      port: 27017
+      targetPort: 27017
+---
+# MongoDB Deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: oqm-mongodb
+  namespace: openquartermaster
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: oqm-mongodb
+  template:
+    metadata:
+      labels:
+        app: oqm-mongodb
+    spec:
+      containers:
+        - name: mongodb
+          image: mongo:7.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 27017
+          envFrom:
+            - secretRef:
+                name: oqm-mongodb-secret
+          volumeMounts:
+            - name: mongodb-data
+              mountPath: /data/db
+          resources:
+            requests:
+              cpu: 200m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 1Gi
+          livenessProbe:
+            exec:
+              command:
+                - mongosh
+                - --eval
+                - "db.adminCommand('ping')"
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 10
+          readinessProbe:
+            exec:
+              command:
+                - mongosh
+                - --eval
+                - "db.adminCommand('ping')"
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+      volumes:
+        - name: mongodb-data
+          persistentVolumeClaim:
+            claimName: oqm-mongodb-data

--- a/apps/openquartermaster/namespace.yaml
+++ b/apps/openquartermaster/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openquartermaster
+  labels:
+    app.kubernetes.io/part-of: openquartermaster

--- a/apps/openquartermaster/secrets.yaml
+++ b/apps/openquartermaster/secrets.yaml
@@ -1,0 +1,35 @@
+---
+# MongoDB credentials for OQM
+apiVersion: v1
+kind: Secret
+metadata:
+  name: oqm-mongodb-secret
+  namespace: openquartermaster
+type: Opaque
+stringData:
+  MONGO_INITDB_ROOT_USERNAME: "oqm-admin"
+  MONGO_INITDB_ROOT_PASSWORD: "changeme-mongo-password"
+---
+# Keycloak admin credentials
+apiVersion: v1
+kind: Secret
+metadata:
+  name: oqm-keycloak-secret
+  namespace: openquartermaster
+type: Opaque
+stringData:
+  KEYCLOAK_ADMIN: "admin"
+  KEYCLOAK_ADMIN_PASSWORD: "changeme-keycloak-password"
+  KC_DB_PASSWORD: "changeme-kc-db-password"
+---
+# PostgreSQL credentials for Keycloak
+apiVersion: v1
+kind: Secret
+metadata:
+  name: oqm-keycloak-db-secret
+  namespace: openquartermaster
+type: Opaque
+stringData:
+  POSTGRES_USER: "keycloak"
+  POSTGRES_PASSWORD: "changeme-kc-db-password"
+  POSTGRES_DB: "keycloak"


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @orriborri :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro Web](https://kiro.dev/web/)</sub>

---
## Summary

Adds a full [OpenQuartermaster](https://openquartermaster.com/public/) (OQM) inventory management system deployment to the homelab cluster.

## Changes

- **New namespace**: `openquartermaster` — keeps all OQM resources isolated
- **Infrastructure components**:
  - MongoDB 7.0 — primary database for the Core API
  - Redpanda v24.1.7 — lightweight Kafka-compatible message broker
  - Keycloak 25.0 — OIDC authentication provider with its own PostgreSQL 16 instance
- **Application components**:
  - OQM Core API v6.1.0 — backend inventory management service
  - OQM Base Station v1.19.2 — web-based UI frontend
- **Ingress routes** (private ingress class):
  - `oqm.orriborri.com` — Base Station UI
  - `oqm-api.orriborri.com` — Core API (direct access)
  - `oqm-auth.orriborri.com` — Keycloak admin/auth
- **Secrets**: Placeholder credentials for MongoDB, Keycloak, and PostgreSQL (should be replaced with real secrets before deployment)

## Architecture

```
User → Base Station (UI) → Core API → MongoDB
                ↕                ↕
           Keycloak          Kafka/Redpanda
              ↓
         PostgreSQL
```

## Post-merge TODO

1. Replace placeholder passwords in `secrets.yaml` with real values (or encrypt with SOPS)
2. Configure Keycloak realm `oqm` with appropriate clients (`oqm-core-api`, `oqm-base-station`)
3. Verify NFS storage class `nfs-client` is available for PVCs
4. Adjust resource limits based on actual cluster capacity

## Testing

- Manifests follow existing homelab patterns (Kustomize, private ingress class, NFS storage)
- Validated YAML structure consistency with other apps in the repo